### PR TITLE
Disable external initializers

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -46,3 +46,7 @@ static const char* const kOrtSessionOptionsConfigSetDenormalAsZero = "session.se
 // "1": enable. ORT does fusion logic for QDQ format.
 // Its default value is "1"
 static const char* const kOrtSessionOptionsEnableQuantQDQ = "session.enable_quant_qdq";
+
+// Key for disabling the option to load tensors from external files in model definition.
+// If the config value is set to "1" then loading external data is disabled, otherwise it is enabled (default value)
+static const char* const kOrtSessionOptionsConfigDisableExternalData = "session.disable_external_data";

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1125,7 +1125,14 @@ common::Status InferenceSession::Initialize() {
 
       have_cpu_ep = execution_providers_.Get(onnxruntime::kCpuExecutionProvider) != nullptr;
     }
-
+    // Verify that there are no external initializers in the graph if external data is disabled.
+    onnxruntime::Graph& graph = model_->MainGraph();
+    if (session_options_.GetConfigOrDefault(kOrtSessionOptionsConfigDisableExternalData, "0") == "1") {
+      const InitializedTensorSet& initializers = graph.GetAllInitializedTensors();
+      for (auto& it: initializers) {
+        ORT_ENFORCE(!utils::HasExternalData(*it.second), "Initializer tensors with external data is not allowed.");
+      }
+    }
     // Register default CPUExecutionProvider if user didn't provide it through the Register() calls.
     // RegisterExecutionProvider locks the session_mutex_ so we can't be holding it when we call that
     if (!have_cpu_ep) {
@@ -1173,8 +1180,6 @@ common::Status InferenceSession::Initialize() {
         *session_logger_,
         session_profiler_,
         session_options_.use_deterministic_compute);
-
-    onnxruntime::Graph& graph = model_->MainGraph();
 
     // Collect the kernel registries from execution provider instances;
     // There are 2 kinds of kernel registries with priority from high to low as below,

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1445,10 +1445,9 @@ TEST(CApiTest, TestCustomDeviceAllocator) {
 
   // create session while allocating the model with the custom allocator.
   ASSERT_EQ(memory_inuse, 0);
-  size_t model_size = 256;
   {
     Ort::Session session1(*ort_env, MODEL_URI, session_options);
-    ASSERT_EQ(memory_inuse, model_size+sizeof(size_t));
+    ASSERT_TRUE(memory_inuse> 0);
     RunSession<float>(my_allocator,
                       session1,
                       inputs,
@@ -1553,10 +1552,9 @@ TEST(CApiTest, TestCustomArenaAllocator) {
 
   // create session while allocating the model with the custom arena allocator.
   ASSERT_EQ(ArenaUsed(), 0);
-  size_t model_size = 256;
   {
     Ort::Session session1(*ort_env, MODEL_URI, session_options);
-    ASSERT_EQ(ArenaUsed(), model_size);
+    ASSERT_TRUE(memory_inuse > 0);
     ASSERT_EQ(reserved_chunks.size(), 1);
     RunSession<float>(my_device_allocator,
         session1,

--- a/onnxruntime/test/shared_lib/test_model_loading.cc
+++ b/onnxruntime/test/shared_lib/test_model_loading.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/session/onnxruntime_cxx_api.h"
+#include "onnxruntime_session_options_config_keys.h"
 #ifdef USE_CUDA
 #include "core/providers/cuda/cuda_provider_factory.h"
 #endif
@@ -56,6 +57,28 @@ TEST(CApiTest, model_from_array) {
   create_session(so);
 #endif
 }
+
+
+TEST(CApiTest, TestDisableExternalInitiliazers) {
+
+  const char* model_path = "testdata/model_with_external_initializers.onnx";
+
+  Ort::SessionOptions so;
+  try {
+    Ort::Session session(*ort_env.get(), model_path, so);
+  } catch (const std::exception& ex) {
+    ASSERT_TRUE(false) << "Creation of session should not have thrown exception" << ex.what();
+  }
+
+  so.AddConfigEntry(kOrtSessionOptionsConfigDisableExternalData, "1");
+  try {
+    Ort::Session session(*ort_env.get(), model_path, so);
+    ASSERT_TRUE(false) << "Creation of session should have thrown exception";
+  } catch (const std::exception& ex) {
+    ASSERT_THAT(ex.what(), testing::HasSubstr("Initializer tensors with external data is not allowed."));
+  }
+}
+
 #endif
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/testdata/model_with_external_initiliazer.py
+++ b/onnxruntime/test/testdata/model_with_external_initiliazer.py
@@ -1,0 +1,64 @@
+import os
+import onnx
+import numpy as np
+from onnx import helper
+from onnx import TensorProto
+from onnx.numpy_helper import from_array
+from onnx.external_data_helper import set_external_data
+
+
+def create_external_data_tensor(value, tensor_name):  # type: (List[Any], Text) -> TensorProto
+    tensor = from_array(np.array(value))
+    tensor.name = tensor_name
+    tensor_filename = "{}.bin".format(tensor_name)
+    set_external_data(tensor, location=tensor_filename)
+
+    with open(os.path.join(tensor_filename), 'wb') as data_file:
+        data_file.write(tensor.raw_data)
+    tensor.ClearField('raw_data')
+    tensor.data_location = onnx.TensorProto.EXTERNAL
+    return tensor
+
+
+def GenerateModel(model_name):
+    # Create one input (ValueInfoProto)
+    X = helper.make_tensor_value_info('X', TensorProto.FLOAT, [1, 2])
+
+    # Create second input (ValueInfoProto)
+    Pads = helper.make_tensor_value_info('Pads', TensorProto.INT64, [4])
+
+    # Create one output (ValueInfoProto)
+    Y = helper.make_tensor_value_info('Y', TensorProto.FLOAT, [1, 4])
+
+    # Create a node (NodeProto)
+    node_def = helper.make_node(
+        'Pad', # node name
+        ['X', 'Pads'], # inputs
+        ['Y'], # outputs
+        mode='constant', # Attributes
+    )
+
+    # Create the graph (GraphProto)
+    graph_def = helper.make_graph(
+        [node_def],
+        "test-model",
+        [X, Pads],
+        [Y],
+        [create_external_data_tensor([0, 0, 1, 1, ], "Pads")]
+    )
+
+    # Create the model (ModelProto)
+    model_def = helper.make_model(graph_def,
+                                  producer_name='onnx-example')
+
+    print('The ir_version in model: {}\n'.format(model_def.ir_version))
+    print('The producer_name in model: {}\n'.format(model_def.producer_name))
+    print('The graph in model:\n{}'.format(model_def.graph))
+    onnx.checker.check_model(model_def)
+    print('The model is checked!')
+    with open(model_name, "wb") as model_file:
+        model_file.write(model_def.SerializeToString())
+
+
+if __name__ == "__main__":
+    GenerateModel('model_with_external_initializers.onnx')


### PR DESCRIPTION
Add a config option that will disable loading model with initializes that have an external data (+test it).
