### PR TITLE
Add the option to disable external initializers as a build option

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -114,6 +114,7 @@ option(onnxruntime_USE_TELEMETRY "Build with Telemetry" OFF)
 #It's default OFF because it's experimental now.
 option(onnxruntime_PREFER_SYSTEM_LIB "Experimental: Build with the preinstalled libraries in your system" OFF)
 option(onnxruntime_USE_ROCM "Build with AMD GPU support" OFF)
+option(onnxruntime_DISABLE_EXTERNAL_INITIALIZERS "Don't allow models to load external data" OFF)
 
 # Options related to reducing the binary size produced by the build
 option(onnxruntime_DISABLE_CONTRIB_OPS "Disable contrib ops" OFF)
@@ -1527,6 +1528,10 @@ if (WINDOWS_STORE)
     target_link_options(onnxruntime PRIVATE /SAFESEH)
     target_link_options(winml_dll PRIVATE /SAFESEH)
   endif()
+endif()
+
+if(onnxruntime_DISABLE_EXTERNAL_INITIALIZERS)
+  add_definitions(-DDISABLE_EXTERNAL_INITIALIZERS=1)
 endif()
 
 include(flake8.cmake)

--- a/onnxruntime/test/shared_lib/test_model_loading.cc
+++ b/onnxruntime/test/shared_lib/test_model_loading.cc
@@ -58,7 +58,7 @@ TEST(CApiTest, model_from_array) {
 #endif
 }
 
-
+#ifdef DISABLE_EXTERNAL_INITIALIZERS
 TEST(CApiTest, TestDisableExternalInitiliazers) {
 
   const char* model_path = "testdata/model_with_external_initializers.onnx";
@@ -66,19 +66,12 @@ TEST(CApiTest, TestDisableExternalInitiliazers) {
   Ort::SessionOptions so;
   try {
     Ort::Session session(*ort_env.get(), model_path, so);
-  } catch (const std::exception& ex) {
-    ASSERT_TRUE(false) << "Creation of session should not have thrown exception" << ex.what();
-  }
-
-  so.AddConfigEntry(kOrtSessionOptionsConfigDisableExternalData, "1");
-  try {
-    Ort::Session session(*ort_env.get(), model_path, so);
     ASSERT_TRUE(false) << "Creation of session should have thrown exception";
   } catch (const std::exception& ex) {
     ASSERT_THAT(ex.what(), testing::HasSubstr("Initializer tensors with external data is not allowed."));
   }
 }
-
+#endif
 #endif
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
Change the way of validating that external initializers are not used in ONNX models - by using a build option instead of session_config option. To use this option, we need to build ONNX with `--cmake_extra_defines onnxruntime_DISABLE_EXTERNAL_INITIALIZERS=ON`

For example:
`./build.sh --config Debug --build_shared_lib --parallel --cmake_extra_defines onnxruntime_DISABLE_EXTERNAL_INITIALIZERS=ON`
